### PR TITLE
Fixed problem with creation of aws spot instances

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,7 +68,7 @@ type Config struct {
 	Tags               []string `json:"tags"`
 	TFStatePath        string   `json:"tf_state_path"`
 	Version            string   `json:"version"`
-	VMProvisioningType string   `json:"vm_provisioning_type""`
+	VMProvisioningType string   `json:"vm_provisioning_type"`
 	WorkerType         string   `json:"worker_type"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -68,7 +68,7 @@ type Config struct {
 	Tags               []string `json:"tags"`
 	TFStatePath        string   `json:"tf_state_path"`
 	Version            string   `json:"version"`
-	VMProvisioningType string   `json:vm_provisioning_type`
+	VMProvisioningType string   `json:"vm_provisioning_type""`
 	WorkerType         string   `json:"worker_type"`
 }
 
@@ -352,5 +352,5 @@ func (c Config) IsGithubAuthSet() bool {
 }
 
 func (c Config) IsSpot() bool {
-	return c.Spot
+	return c.VMProvisioningType == SPOT
 }


### PR DESCRIPTION
Fixed a bug that prevented AWS spot configuration from being created in the cloud-config.yml.
Additionally to the committed changes we had the problem, that no spot request was issued, when `spot_ondemand_fallback: true` was set.