### PR TITLE
Consistent "Name" tag (with uppercase N)

### DIFF
--- a/resource/assets/aws/infrastructure.tf
+++ b/resource/assets/aws/infrastructure.tf
@@ -213,7 +213,7 @@ resource "aws_route" "internet_access" {
   depends_on = ["aws_internet_gateway.default"]
 
     tags {
-    name = "${var.deployment}"
+    Name = "${var.deployment}"
     control-tower-project = "${var.project}"
   }
 }
@@ -279,7 +279,7 @@ resource "aws_eip" "director" {
   depends_on = ["aws_internet_gateway.default"]
 
     tags {
-    name = "${var.deployment}-director"
+    Name = "${var.deployment}-director"
     control-tower-project = "${var.project}"
   }
 }
@@ -289,7 +289,7 @@ resource "aws_eip" "atc" {
   depends_on = ["aws_internet_gateway.default"]
 
     tags {
-    name = "${var.deployment}-atc"
+    Name = "${var.deployment}-atc"
     control-tower-project = "${var.project}"
   }
 }
@@ -299,7 +299,7 @@ resource "aws_eip" "nat" {
   depends_on = ["aws_internet_gateway.default"]
 
     tags {
-    name = "${var.deployment}-nat"
+    Name = "${var.deployment}-nat"
     control-tower-project = "${var.project}"
   }
 }


### PR DESCRIPTION
AWS resource tags are case sensitive.  The "Name" tag is pretty standard, and widely used, but some of the control-tower resources have a "name" tag, which is confusing, especially as many screens in the AWS console automatically show the "Name" tag but not the "name" tag.  This commit consistently tags resources with the "Name" tag.