### PR TITLE
fixed issue with bucket name not being determined

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -162,12 +162,12 @@ func determineBucketName(iaas iaas.Provider, namespace, project string) (string,
 	namespaceBucketName := createBucketName(deployment(project), namespace)
 
 	foundRegionNamedBucket, err := iaas.BucketExists(regionBucketName)
+	var foundNamespacedBucket bool
 	if err != nil {
-		return "", false, err
-	}
-	foundNamespacedBucket, err := iaas.BucketExists(namespaceBucketName)
-	if err != nil {
-		return "", false, err
+		foundNamespacedBucket, err = iaas.BucketExists(namespaceBucketName)
+		if err != nil {
+			return "", false, err
+		}
 	}
 
 	foundOne := foundRegionNamedBucket || foundNamespacedBucket


### PR DESCRIPTION
Problem: Bucket name could not be determined. 

Error: error ensuring config bucket exists before deploy: [error determining if bucket [] exists: [InvalidParameter: 1 validation error(s) found.
- minimum field size of 1, HeadBucketInput.Bucket.

Note: This has been tested out and resolved our issues internally. 

Fixes #27 