### PR TITLE
Adds optional x-frame-options configuration

### DIFF
--- a/bosh/aws_concourse.go
+++ b/bosh/aws_concourse.go
@@ -61,6 +61,7 @@ func (client *AWSClient) deployConcourse(creds []byte, detach bool) ([]byte, err
 		"atc_encryption_key":       client.config.GetEncryptionKey(),
 		"web_static_ip":            atcPrivateIP.String(),
 		"enable_global_resources":  client.config.GetEnableGlobalResources(),
+		"x_frame_options":          client.config.GetXFrameOptions(),
 	}
 
 	flagFiles := []string{

--- a/bosh/gcp_concourse.go
+++ b/bosh/gcp_concourse.go
@@ -72,6 +72,7 @@ func (client *GCPClient) deployConcourse(creds []byte, detach bool) ([]byte, err
 		"network_name":             networkName,
 		"web_static_ip":            atcPrivateIP.String(),
 		"enable_global_resources":  client.config.GetEnableGlobalResources(),
+		"x_frame_options":          client.config.GetXFrameOptions(),
 	}
 
 	flagFiles := []string{

--- a/ci/tasks/system-test-options-and-destroy.sh
+++ b/ci/tasks/system-test-options-and-destroy.sh
@@ -69,6 +69,9 @@ eval "$info_output"
 global_resources_path="/instance_groups/name=web/jobs/name=web/properties/enable_global_resources"
 checkManifestProperty "${global_resources_path}" false
 
+x_frame_options_path="/instance_groups/name=web/jobs/name=web/properties/x_frame_options"
+checkManifestProperty "${x_frame_options_path}" "deny"
+
 if [ "$IAAS" = "AWS" ]
 then
     assertNetworkCidrsCorrect 192.168.0.0/27 192.168.0.32/27 192.168.0.0/24 192.168.0.64/28 192.168.0.80/28

--- a/ci/tasks/system-test.sh
+++ b/ci/tasks/system-test.sh
@@ -50,7 +50,8 @@ echo "DEPLOY WITH A USER PROVIDED CERT, CUSTOM DOMAIN, DEFAULT WORKERS, DEFAULT 
   --spot=false \
   --tls-cert "$(cat out/"$custom_domain".crt)" \
   --tls-key "$(cat out/"$custom_domain".key)" \
-  --enable-global-resources=true
+  --enable-global-resources=true \
+  --x-frame-options=sameorigin
 
 sleep 60
 
@@ -83,6 +84,10 @@ assertConfigBucketVersioned
 global_resources_path="/instance_groups/name=web/jobs/name=web/properties/enable_global_resources"
 checkManifestProperty "${global_resources_path}" true
 
+# Check X-Frame-Options is correctly set
+x_frame_options_path="/instance_groups/name=web/jobs/name=web/properties/x_frame_options"
+checkManifestProperty "${x_frame_options_path}" "sameorigin"
+
 # shellcheck disable=SC2034
 cert="generated-ca-cert.pem"
 # shellcheck disable=SC2034
@@ -105,7 +110,8 @@ waitForBoshLock
   --allow-ips "$(dig +short myip.opendns.com @resolver1.opendns.com)" \
   --workers 2 \
   --worker-size large \
-  --enable-global-resources=false
+  --enable-global-resources=false \
+  --x-frame-options=\'allow-from https://www.engineerbetter.com\'
 
 sleep 60
 
@@ -114,6 +120,9 @@ assertDbCorrect
 
 # Check Concourse global resources is disabled
 checkManifestProperty "${global_resources_path}" false
+
+# Check X-Frame-Options is correctly set
+checkManifestProperty "${x_frame_options_path}" "allow-from https://www.engineerbetter.com"
 
 config=$(./cup info --json "$deployment")
 # shellcheck disable=SC2034

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -185,6 +185,13 @@ var deployFlags = []cli.Flag{
 		EnvVar:      "RDS_SUBNET_RANGE2",
 		Destination: &initialDeployArgs.RDS2CIDR,
 	},
+	cli.StringFlag{
+		Name:        "x-frame-options",
+		Usage:       "(optional) set the X-Frame-Options HTTP header that the web worker responds with. deny/sameorigin are supported options, ALLOW-FROM uri is supported on some older browsers (default: deny)",
+		EnvVar:      "X_FRAME_OPTIONS",
+		Value:       "deny",
+		Destination: &initialDeployArgs.XFrameOptions,
+	},
 }
 
 func deployAction(c *cli.Context, deployArgs deploy.Args, provider iaas.Provider) error {

--- a/commands/deploy/deploy_args.go
+++ b/commands/deploy/deploy_args.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"gopkg.in/urfave/cli.v1"
 )
@@ -45,23 +46,25 @@ type Args struct {
 	GithubAuthIsSet bool
 	Tags            cli.StringSlice
 	// TagsIsSet is true if the user has specified tags using --tags
-	TagsIsSet        bool
-	Spot             bool
-	SpotIsSet        bool
-	Zone             string
-	ZoneIsSet        bool
-	WorkerType       string
-	WorkerTypeIsSet  bool
-	NetworkCIDR      string
-	NetworkCIDRIsSet bool
-	PublicCIDR       string
-	PublicCIDRIsSet  bool
-	PrivateCIDR      string
-	PrivateCIDRIsSet bool
-	RDS1CIDR         string
-	RDS1CIDRIsSet    bool
-	RDS2CIDR         string
-	RDS2CIDRIsSet    bool
+	TagsIsSet          bool
+	Spot               bool
+	SpotIsSet          bool
+	Zone               string
+	ZoneIsSet          bool
+	WorkerType         string
+	WorkerTypeIsSet    bool
+	NetworkCIDR        string
+	NetworkCIDRIsSet   bool
+	PublicCIDR         string
+	PublicCIDRIsSet    bool
+	PrivateCIDR        string
+	PrivateCIDRIsSet   bool
+	RDS1CIDR           string
+	RDS1CIDRIsSet      bool
+	RDS2CIDR           string
+	RDS2CIDRIsSet      bool
+	XFrameOptions      string
+	XFrameOptionsIsSet bool
 }
 
 // MarkSetFlags is marking the IsSet DeployArgs
@@ -117,6 +120,8 @@ func (a *Args) MarkSetFlags(c FlagSetChecker) error {
 				a.RDS1CIDRIsSet = true
 			case "rds-subnet-range2":
 				a.RDS2CIDRIsSet = true
+			case "x-frame-options":
+				a.XFrameOptionsIsSet = true
 			default:
 				return fmt.Errorf("flag %q is not supported by deployment flags", f)
 			}
@@ -167,6 +172,10 @@ func (a Args) Validate() error {
 	}
 
 	if err := a.validateTags(); err != nil {
+		return err
+	}
+
+	if err := a.validateXFrameOptions(); err != nil {
 		return err
 	}
 
@@ -250,6 +259,22 @@ func (a Args) validateTags() error {
 		}
 	}
 	return nil
+}
+
+func (a Args) validateXFrameOptions() error {
+	lowerXFrameOptions := strings.ToLower(a.XFrameOptions)
+
+	switch lowerXFrameOptions {
+	case "deny":
+		return nil
+	case "sameorigin":
+		return nil
+	default:
+		if strings.Contains(lowerXFrameOptions, "allow-from") {
+			return nil
+		}
+		return fmt.Errorf("unknown x-frame-options `%s`. Valid options are deny, sameorigin, allow-from uri", a.XFrameOptions)
+	}
 }
 
 // FlagSetChecker allows us to find out if flags were set, adn what the names of all flags are

--- a/commands/deploy/deploy_args_test.go
+++ b/commands/deploy/deploy_args_test.go
@@ -25,6 +25,7 @@ func TestDeployArgs_Validate(t *testing.T) {
 		WebSize:                "small",
 		WorkerCount:            1,
 		WorkerSize:             "xlarge",
+		XFrameOptions:          "deny",
 	}
 	tests := []struct {
 		name         string

--- a/concourse/config.go
+++ b/concourse/config.go
@@ -166,6 +166,10 @@ func applyArgumentsToConfig(conf config.Config, deployArgs *deploy.Args, provide
 		conf.EnableGlobalResources = deployArgs.EnableGlobalResources
 	}
 
+	if deployArgs.XFrameOptionsIsSet {
+		conf.XFrameOptions = deployArgs.XFrameOptions
+	}
+
 	var isDomainUpdated bool
 	if deployArgs.DomainIsSet {
 		if conf.Domain != deployArgs.Domain {

--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,7 @@ type Config struct {
 	Version            string   `json:"version"`
 	VMProvisioningType string   `json:"vm_provisioning_type"`
 	WorkerType         string   `json:"worker_type"`
+	XFrameOptions      string   `json:"x_frame_options"`
 }
 
 type ConfigView interface {
@@ -129,6 +130,7 @@ type ConfigView interface {
 	GetTFStatePath() string
 	GetVersion() string
 	GetWorkerType() string
+	GetXFrameOptions() string
 	IsGithubAuthSet() bool
 	IsSpot() bool
 }
@@ -351,6 +353,10 @@ func (c Config) GetVersion() string {
 
 func (c Config) GetWorkerType() string {
 	return c.WorkerType
+}
+
+func (c Config) GetXFrameOptions() string {
+	return c.XFrameOptions
 }
 
 func (c Config) IsGithubAuthSet() bool {


### PR DESCRIPTION
Adds the ability to configure the [`X-Frame-Options`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) of the concourse web worker according to #67 .

### Open questions:

The aim here really would be for the `X-Frame-Options` header to *not* be sent from concourse web (if you wanted to allow your pipeline to be embedded in other dashboards). However, _somehow_ our control-tower concourse deployment, the default seems to be `deny`.

There are only two "properly" supported `X-Frame-Options` (`DENY`/`SAMEORIGIN`). Aka: no `ALLOW`. There is an `ALLOW-FROM uri` option, which is no longer supported by most browsers. In this case, the browser would completely ignore the header. This is what I in particular want, but it's a sneaky workaround, and could lead to a false sense of security.

So:

- `X-Frame-Options` is already default deny (changing the default might have unintended consequences)
- I don't know how to "not" set the `X-Frame-Options` header (any ideas how to debug this? 🤔)
- Allowing `ALLOW-FROM uri` does not feel like a sustainable solution.

### Other small things:

Small vs. upper case `deny` vs `DENY` options? (validation currently checks against lowercase)


### TODO: 
- Run full testing suite (not just `./run_tests_local`)?
- Update `control-tower-ops` manifest