### PR TITLE
AWS Fix for support list of IPs with All Trafic's rule

### DIFF
--- a/iaas/aws.go
+++ b/iaas/aws.go
@@ -150,9 +150,12 @@ func (a *AWSProvider) CheckForWhitelistedIP(ip, securityGroup string) (bool, err
 			}
 			// support "All traffic rules"
 			if *entry.IpProtocol == "-1" {
-				return parsedCIDR.Contains(parsedIP), nil
+				if parsedCIDR.Contains(parsedIP) {
+					return true, nil
+				}
+			} else {
+				checkPorts(parsedCIDR, parsedIP, &port22, &port6868, &port25555, *entry.FromPort, *entry.ToPort)
 			}
-			checkPorts(parsedCIDR, parsedIP, &port22, &port6868, &port25555, *entry.FromPort, *entry.ToPort)
 		}
 	}
 


### PR DESCRIPTION
- **Issue**

https://github.com/EngineerBetter/control-tower/issues/69

- **Desc**

In my AWS EC2 Security Group setup exist a number of IP address with All Traffic inbound rules.
So even the host's IP is present in the group still getting the error: Do you need to add your IP to security group... ?

- **Fix** 

Break the loop only if IP address found / `parsedCIDR.Contains(parsedIP)` , aka __true__ and continue with check on next address in the list, if exist.

- **Test**

Create a group with number of __All Traffic__ rules and verify that logic iterate over all of them.