### PR TITLE
Fix - Upgrade default postgres RDS version from 9.6.11 to 9.6.18

### DIFF
--- a/resource/assets/aws/infrastructure.tf
+++ b/resource/assets/aws/infrastructure.tf
@@ -590,7 +590,7 @@ resource "aws_db_instance" "default" {
   port                   = 5432
   engine                 = "postgres"
   instance_class         = "${var.rds_instance_class}"
-  engine_version         = "9.6.11"
+  engine_version         = "9.6.18"
   name                   = "${var.rds_default_database_name}"
   username               = "${var.rds_instance_username}"
   password               = "${var.rds_instance_password}"


### PR DESCRIPTION
Upgrade the default postgres version in AWS RDS from 9.6.11 to 9.6.18.