### PR TITLE
Add a property to enable the disk encryption for postgres databases on AWS

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -127,6 +127,13 @@ var deployFlags = []cli.Flag{
 		Value:       "small",
 		Destination: &initialDeployArgs.DBSize,
 	},
+	cli.BoolFlag{
+		Name:        "rds-disk-encryption",
+		Usage:       "(optional) Use a aws rds database with an encrypted disk. The KMS key is created automatically.",
+		EnvVar:      "RDSDiskEncryption",
+		Hidden:      true,
+		Destination: &initialDeployArgs.RDSDiskEncryption,
+	},
 	cli.BoolTFlag{
 		Name:        "spot",
 		Usage:       "(optional) Use spot instances for workers. Can be true/false (default: true)",

--- a/commands/deploy/deploy_args.go
+++ b/commands/deploy/deploy_args.go
@@ -36,6 +36,8 @@ type Args struct {
 	DBSize              string
 	// DBSizeIsSet is true if the user has manually specified the db-size (ie, it's not the default)
 	DBSizeIsSet                    bool
+	RDSDiskEncryption              bool
+	RDSDiskEncryptionIsSet         bool
 	EnableGlobalResources          bool
 	EnableGlobalResourcesIsSet     bool
 	EnablePipelineInstances        bool
@@ -136,6 +138,8 @@ func (a *Args) MarkSetFlags(c FlagSetChecker) error {
 				a.SelfUpdateIsSet = true
 			case "db-size":
 				a.DBSizeIsSet = true
+			case "rds-disk-encryption":
+				a.RDSDiskEncryptionIsSet = true
 			case "spot", "preemptible":
 				a.SpotIsSet = true
 			case "allow-ips":

--- a/concourse/config.go
+++ b/concourse/config.go
@@ -79,6 +79,10 @@ func assertImmutableFieldsNotChanging(deployArgs *deploy.Args, conf config.Confi
 		return fmt.Errorf("Existing deployment uses zone %s and cannot change to zone %s", conf.GetAvailabilityZone(), deployArgs.Zone)
 	}
 
+	if deployArgs.RDSDiskEncryption != conf.GetRDSDiskEncryption() {
+		return fmt.Errorf("The disk encryption cannot be changed after inital deploy!")
+	}
+
 	return nil
 }
 
@@ -109,6 +113,7 @@ func populateConfigWithDefaults(conf config.Config, provider iaas.Provider, pass
 	conf.RDSInstanceClass = provider.DBType("small")
 	conf.RDSPassword = passwordGenerator(defaultPasswordLength)
 	conf.RDSUsername = "admin" + passwordGenerator(7)
+	conf.RDSDiskEncryption = false
 	conf.VMProvisioningType = config.SPOT
 	conf.WorkerType = "m4"
 	conf = populateConfigWithDefaultCIDRs(conf, provider)
@@ -161,6 +166,9 @@ func applyArgumentsToConfig(conf config.Config, deployArgs *deploy.Args, provide
 	}
 	if deployArgs.DBSizeIsSet {
 		conf.RDSInstanceClass = provider.DBType(deployArgs.DBSize)
+	}
+	if deployArgs.RDSDiskEncryptionIsSet {
+		conf.RDSDiskEncryption = deployArgs.RDSDiskEncryption
 	}
 	if deployArgs.BitbucketAuthIsSet {
 		conf.BitbucketClientID = deployArgs.BitbucketAuthClientID

--- a/concourse/tf_input_vars_factory.go
+++ b/concourse/tf_input_vars_factory.go
@@ -62,6 +62,7 @@ func (f *AWSInputVarsFactory) NewInputVars(c config.ConfigView) terraform.InputV
 		RDSInstanceClass:       c.GetRDSInstanceClass(),
 		RDSPassword:            c.GetRDSPassword(),
 		RDSUsername:            c.GetRDSUsername(),
+		RDSDiskEncryption:      c.GetRDSDiskEncryption(),
 		RDS1CIDR:               c.GetRDS1CIDR(),
 		RDS2CIDR:               c.GetRDS2CIDR(),
 		Region:                 c.GetRegion(),

--- a/config/config.go
+++ b/config/config.go
@@ -77,6 +77,7 @@ type Config struct {
 	RDSInstanceClass         string `json:"rds_instance_class"`
 	RDSPassword              string `json:"rds_password"`
 	RDSUsername              string `json:"rds_username"`
+	RDSDiskEncryption        bool   `json:"rds_disk_encryption"`
 	Region                   string `json:"region"`
 	SourceAccessIP           string `json:"source_access_ip"`
 	//Spot is deprecated, exists only as we need to migrate old configs to VMProvisioningType
@@ -152,6 +153,7 @@ type ConfigView interface {
 	GetRDSInstanceClass() string
 	GetRDSPassword() string
 	GetRDSUsername() string
+	GetRDSDiskEncryption() bool
 	GetRegion() string
 	GetSourceAccessIP() string
 	GetTags() []string
@@ -417,6 +419,10 @@ func (c Config) GetRDSPassword() string {
 
 func (c Config) GetRDSUsername() string {
 	return c.RDSUsername
+}
+
+func (c Config) GetRDSDiskEncryption() bool {
+	return c.RDSDiskEncryption
 }
 
 func (c Config) GetRegion() string {

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -123,6 +123,15 @@ control-tower deploy \
 
 > This flag overwrites the allowed IPs on every deploy. This means deploying with `allow-ips` then deploying again without it will reset the allow list to `0.0.0.0/0`. The self-update pipeline will maintain the `allow-ips` of the most recent deploy.
 
+## RDS Disk encryption
+
+On GCP the database disk encryption is enabled by default. On AWS we added the option to enable the disk encryption too. By default it's disabled.
+> Note that you can only change this value during the inital deploy. It's not possible to change this for a running instance.
+
+| **Flag**                | **Description**                                                                      | **Environment Variable** |
+| :-----------------------| :----------------------------------------------------------------------------------- | :----------------------- |
+| `--rds-disk-encryption` | Optional configuration to use an encrypted rds disk for AWS. Not enabled by default! | `RDSDiskEncryption`      |
+
 ## BitBucket Auth
 
 | **Flag**                               | **Description**                                                           | **Environment Variable**       |

--- a/terraform/aws.go
+++ b/terraform/aws.go
@@ -29,6 +29,7 @@ type AWSInputVars struct {
 	RDSInstanceClass       string
 	RDSPassword            string
 	RDSUsername            string
+	RDSDiskEncryption      bool
 	RDS1CIDR               string
 	RDS2CIDR               string
 	Region                 string


### PR DESCRIPTION
We added the possibility to use encrypted disks for AWS Postgres Databases. The new property can be used during the inital deployment. Changes for already existing databases are not supported. Terraform would replace them with complete data lose.

Implementation steps:

    - Add a KMS Key + Alias and connect them to the database
    - Add a cli property to use the encrypted disk for AWS
    - Deploy KMS Key + Alias only if the disk encryption is enabled
    - Update the documentation